### PR TITLE
Card query fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "helmet": "^6.0.0",
         "immutable-json-patch": "^6.0.1",
         "node-cron": "^3.0.2",
-        "prisma-extension-random": "^0.2.2",
         "socket.io": "^4.5.1",
         "uuid": "^8.3.2"
       },
@@ -3220,14 +3219,6 @@
       },
       "engines": {
         "node": ">=16.13"
-      }
-    },
-    "node_modules/prisma-extension-random": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/prisma-extension-random/-/prisma-extension-random-0.2.2.tgz",
-      "integrity": "sha512-tjY5w2pSIgwQh0tDT98KTTYJ0uadUwfbTH+6QbPCfLg+gesgeLZNO4oKv8O6/udx54QvEbyXgNC1LUcjtoypcg==",
-      "peerDependencies": {
-        "@prisma/client": "*"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "helmet": "^6.0.0",
     "immutable-json-patch": "^6.0.1",
     "node-cron": "^3.0.2",
-    "prisma-extension-random": "^0.2.2",
     "socket.io": "^4.5.1",
     "uuid": "^8.3.2"
   },

--- a/server/controllers/sockets.ts
+++ b/server/controllers/sockets.ts
@@ -30,6 +30,7 @@ export default function socketHandler(io: Server<ClientToServerEvents, ServerToC
         return;
       }
 
+      console.log(`socketid ${socket.id} requested room state: sending room data`);
       io.to(socket.id).emit('receiveRoomState', room);
     });
 

--- a/server/gameClasses.ts
+++ b/server/gameClasses.ts
@@ -209,9 +209,23 @@ export class Room implements IRoom {
 
   // draws cards
   async populateHands() {
+    const cardsNeededPerPlayer = this.players.map(p => this.handSize - p.hand.length);
+    // get total number of cards needed in one database call
+    const newCards = await drawCards(cardsNeededPerPlayer.reduce((sum, a) => sum + a, 0));
+    console.log(`${cardsNeededPerPlayer.reduce((sum, a) => sum + a, 0)} cards needed, ${newCards.length} cards drawn`);
     const newCardsPerPlayer: {card: GameCard, handIndex: number}[][] = [];
     for (const player of this.players) {
-      newCardsPerPlayer.push(await player.populateHand(this.handSize));
+      const newCardsForCurrentPlayer: {card: GameCard, handIndex: number}[] = [];
+      for (let handIndex = player.hand.length; handIndex < this.handSize; handIndex += 1) {
+        const card = newCards.pop();
+        if (card !== undefined) {
+          player.hand.push(card);
+          newCardsForCurrentPlayer.push({card, handIndex});
+        } else {
+          console.log('something went wrong - not enough cards drawn');
+        }
+      }
+      newCardsPerPlayer.push(newCardsForCurrentPlayer);
     }
     return newCardsPerPlayer;
   }
@@ -453,13 +467,6 @@ export class Player implements IPlayer {
     this.score = 0;
     this.scoredThisRound = 0;
     this.hand = [];
-  }
-  
-  async populateHand(size: number) {
-    const initialIndex = this.hand.length;
-    const newCards = await drawCards(size - initialIndex);
-    this.hand.push(...newCards);
-    return newCards.map((card, i) => {return {card: card, handIndex: initialIndex + i};});
   }
   
   // removes card from hand and returns the former index of the card

--- a/server/gameClasses.ts
+++ b/server/gameClasses.ts
@@ -210,8 +210,11 @@ export class Room implements IRoom {
   // draws cards
   async populateHands() {
     const cardsNeededPerPlayer = this.players.map(p => this.handSize - p.hand.length);
+    const totalCardsNeeded =  cardsNeededPerPlayer.reduce((sum, a) => sum + a, 0);
+    const currentCardIds = this.players.map(p => p.hand.map(c => c.id)).flat();
+    console.log(`currentCardIds: ${JSON.stringify(currentCardIds)}`);
     // get total number of cards needed in one database call
-    const newCards = await drawCards(cardsNeededPerPlayer.reduce((sum, a) => sum + a, 0));
+    const newCards = await drawCards(totalCardsNeeded, currentCardIds);
     console.log(`${cardsNeededPerPlayer.reduce((sum, a) => sum + a, 0)} cards needed, ${newCards.length} cards drawn`);
     const newCardsPerPlayer: {card: GameCard, handIndex: number}[][] = [];
     for (const player of this.players) {
@@ -222,7 +225,7 @@ export class Room implements IRoom {
           player.hand.push(card);
           newCardsForCurrentPlayer.push({card, handIndex});
         } else {
-          console.log('something went wrong - not enough cards drawn');
+          console.error('something went wrong - not enough cards drawn');
         }
       }
       newCardsPerPlayer.push(newCardsForCurrentPlayer);

--- a/server/models/cardModel.ts
+++ b/server/models/cardModel.ts
@@ -1,16 +1,17 @@
 import { PrismaClient } from '@prisma/client';
 import { GameCard } from '../../types';
-import prismaRandom from 'prisma-extension-random';
 
-const prisma = new PrismaClient().$extends(prismaRandom());
+const prisma = new PrismaClient();
 const imageBucketUrl = process.env.IMAGE_BUCKET;
 
-export async function drawCards(count: number): Promise<GameCard[]>  {
-  const newCards: {id: bigint, locator: string}[] = await prisma.card.findManyRandom(count,
-    {
-      select: { id: true, locator: true}
-    }
-  );
+export async function drawCards(count: number, currentCardIds: string[]): Promise<GameCard[]>  {
+  const newCards = await prisma.$queryRaw<{id: bigint, locator: string}[]>`
+    SELECT id, locator FROM "Card"
+    ORDER BY random()
+    LIMIT ${count};
+  `;
+  console.log(currentCardIds);
+
   return newCards.map(card => {
     return {
       id: card.id.toString(),

--- a/server/models/cardModel.ts
+++ b/server/models/cardModel.ts
@@ -19,6 +19,7 @@ export async function drawCards(count: number): Promise<GameCard[]>  {
   });
 }
 
+// retrieves the card with passed in id if exists, oterwise returns null
 export async function retrieveCardInfo(cardId: bigint): Promise<GameCard | null> {
   const result = await prisma.card.findFirst({
     where: {

--- a/server/models/cardModel.ts
+++ b/server/models/cardModel.ts
@@ -15,14 +15,16 @@ export async function drawCards(count: number, currentCardIds: string[]): Promis
         WHERE id IN (${Prisma.join(currentCardIds.map(cardId => parseInt(cardId)))})
       )
       ORDER BY episode_id, random()
-      LIMIT ${count};
+      LIMIT ${count}
+      OFFSET floor(random() * ((SELECT COUNT(DISTINCT episode_id) FROM "Card") - ${currentCardIds.length} - ${count} + 1))::int;
     ` 
     :
     // case where therer are no currentCardIds to worry about
     await prisma.$queryRaw<{id: bigint, locator: string}[]>`
       SELECT DISTINCT ON (episode_id) id, locator FROM "Card"
       ORDER BY episode_id, random()
-      LIMIT ${count};
+      LIMIT ${count}
+      OFFSET floor(random() * ((SELECT COUNT(DISTINCT episode_id) FROM "Card") - ${count} + 1))::int;
     `;
 
   return newCards.map(card => {


### PR DESCRIPTION
Draws all cards needed for the next round at once instead of over multiple database calls.
Additionally, ensures that every card in a game is from a distinct episode. This improves card variety and eliminates the possibility of duplicate cards or cards from very close timestamps in the same episode.